### PR TITLE
Add onHostCommand callback to sendHostCommand()

### DIFF
--- a/src/ripterm.js
+++ b/src/ripterm.js
@@ -1272,6 +1272,10 @@ class RIPterm {
     // TODO: $ variables & host command templates
 
     this.log('trm', 'send to host: ' + text);
+    // Emit event for external listeners (e.g. BBS game clients)
+    if (this.onHostCommand) {
+      this.onHostCommand(text);
+    }
   }
 
 


### PR DESCRIPTION
## Summary

`sendHostCommand()` currently logs the command but provides no way for external code to receive it.

## Changes

Adds an optional `onHostCommand` callback property that, when set, is called with the command text whenever a RIP button click or mouse region triggers a host command.

## Use Case

This enables BBS game clients and other applications embedding RIPtermJS to intercept and act on host commands sent from RIP UI elements. For example, a BBS door game client can use this to send the command back to the BBS server over a WebSocket connection.

## Usage

```js
const rip = new RIPterm({ canvasId: 'myCanvas' });
rip.onHostCommand = (text) => {
  // Forward the command to the BBS host
  websocket.send(text);
};
```
