### PR TITLE
Fix mouse region sizing for buttons with style dimensions but no image

### DIFF
--- a/src/ripterm.js
+++ b/src/ripterm.js
@@ -1370,7 +1370,13 @@ class RIPterm {
       button.image = JSON.parse(JSON.stringify(this.clipboard));
     }
 
-    // resize if there's an image
+    // apply button style dimensions if specified (matches drawButton logic)
+    if (bstyle.wid && (bstyle.wid > 0) && bstyle.hgt && (bstyle.hgt > 0)) {
+      x2 = x1 + bstyle.wid;
+      y2 = y1 + bstyle.hgt;
+    }
+
+    // resize if there's an image (overrides style dimensions)
     if (button.image && ('width' in button.image) && ('height' in button.image)) {
       x2 = x1 + button.image.width;
       y2 = y1 + button.image.height;


### PR DESCRIPTION
## Summary

Fixes mouse region sizing for buttons that use button style dimensions (`wid`/`hgt`) but have no associated image.

## Problem

In `defineMouseRegion()`, when a button style specifies `wid` and `hgt` dimensions but the button has no associated image, the mouse region bounding box (`x2`, `y2`) is never updated from its initial values. This results in zero-sized or incorrectly-sized mouse regions, causing click detection to fail for such buttons.

This is a problem for RIP applications that define buttons with style dimensions (e.g. text label buttons) rather than icon images.

## Fix

Applies the button style's `wid`/`hgt` to the bounding box before checking for an image, so that:
- Buttons with style dimensions but no image get correctly-sized mouse regions
- Image dimensions still override style dimensions when both are present (image check comes after)

This matches the existing `drawButton()` logic which already uses `bstyle.wid` and `bstyle.hgt` for rendering.
