### PR TITLE
Implement Pop-Up Pick List support (`((...))`)

### DIFF
--- a/src/ripterm.js
+++ b/src/ripterm.js
@@ -1418,12 +1418,81 @@ class RIPterm {
 
     const ctext = this.caretsToControlChars(text);
     const otext = this.controlCharsToSymbols(ctext);
+
+    // Pop-Up Pick Lists: ((...)) triggers a selection popup.
+    // If an onPickList handler is set, emit the parsed list and defer sending
+    // the command until the handler resolves with the user's selection.
+    const pickMatch = ctext.match(/\(\((.+?)\)\)/);
+    if (pickMatch && this.onPickList) {
+      const parsed = this._parsePickList(pickMatch[1]);
+      const resolve = (value) => {
+        if (value == null) value = '';
+        const finalCmd = ctext.substring(0, pickMatch.index) + value +
+          ctext.substring(pickMatch.index + pickMatch[0].length);
+        this.sendHostCommand(finalCmd);
+      };
+      this.onPickList(parsed, resolve);
+      return;
+    }
+
     this.log('trm', `send to host: ${otext}`);
 
     // Emit event for external listeners (e.g. BBS game clients)
     if (this.onHostCommand) {
       this.onHostCommand(ctext);
     }
+  }
+
+  // Parse the inner contents of a ((...)) Pop-Up Pick List.
+  // Returns { prompt, required, entries } where entries is an array of
+  // { value, display, hotkey } objects.
+  //
+  // Spec format: [*]prompt?::entry1[@desc1],entry2[@desc2],...
+  //   - Leading * on prompt means selection is required (ESC disabled)
+  //   - @desc overrides the display text for that entry
+  //   - _x_ or ~x~ in descriptions highlight a hotkey character
+  //
+  _parsePickList (inner) {
+    const sepIdx = inner.indexOf('::');
+    let prompt, required = false, entriesStr;
+
+    if (sepIdx >= 0) {
+      prompt = inner.substring(0, sepIdx).trim();
+      entriesStr = inner.substring(sepIdx + 2);
+    } else {
+      prompt = '';
+      entriesStr = inner;
+    }
+
+    if (prompt.startsWith('*')) {
+      required = true;
+      prompt = prompt.substring(1).trim();
+    }
+    if (!prompt) {
+      prompt = 'Choose one of the following:';
+    }
+
+    const entries = entriesStr.split(',').map(raw => {
+      const atIdx = raw.indexOf('@');
+      let value, display;
+      if (atIdx >= 0) {
+        value = raw.substring(0, atIdx);
+        display = raw.substring(atIdx + 1);
+      } else {
+        value = raw;
+        display = raw;
+      }
+      // Extract hotkey from _x_ or ~x~ markers
+      let hotkey = null;
+      const hkMatch = display.match(/[_~](.)[_~]?/);
+      if (hkMatch) {
+        hotkey = hkMatch[1];
+        display = display.replace(/[_~](.)[_~]?/g, '$1');
+      }
+      return { value: value.trim(), display: display.trim(), hotkey };
+    }).filter(e => e.display);
+
+    return { prompt, required, entries };
   }
 
 


### PR DESCRIPTION
## Add Pop-Up Pick List support (`((...))`)

### Summary

This PR implements the **Pop-Up Pick List** feature from the RIPscrip v1.54 specification. When RIPscrip sends a command string containing a `((...))` pick list token, RIPterm now parses it and emits it to the consuming application via an `onPickList` callback, rather than forwarding the raw `((...))` text to sendHostCommand.

The task of actually rendering the pick list should be a job for the consuming application, so only the callback is called, no UI is rendered by RIPterm.

### Background

RIPscrip v1.54 §6.3 defines Pop-Up Pick Lists as a mechanism for the host to present a menu of labelled choices to the user. The format embedded in a host command string is:

```
(([*]question?::value1[@display1],value2[@display2],...))
```

- A leading `*` on the question marks the selection as required (ESC should be disabled)
- `@display` overrides the label shown to the user for a given entry
- `_x_` or `~x~` markers inside a display string designate a hotkey character

When the `((...))` token is detected, the renderer should present this as a graphical pop-up and, once the user makes a selection, substitute the chosen `value` back into the command string and send the result to the host (sendHostCommand()).

### Changes

#### `sendHostCommand(text)`

- If a `((...))` token is found **and** an `onPickList` handler is registered, `_parsePickList()` is called to produce a structured object and the method returns early; the pick list is handed off to the consuming application rather than sent to the host.
- The `resolve` callback passed to `onPickList` accepts the user's chosen value, splices it into the original command string in place of the `((...))` token, and calls `sendHostCommand()` with the completed string. Cancelling (passing `null` or `undefined`) sends the command with the pick list token removed.

#### `_parsePickList(inner)` *(new method)*

Parses the inner content of a `((...))` token and returns:

```js
{
  prompt: string, // prompt/question text
  required: boolean,  // true if leading * was present
  entries: [
    { value: string, display: string, hotkey: string|null },
    ...
  ]
}
```

The `prompt` (or `question` in the spec, even though all the examples in the spec aren't questions) defaults to "Choose one of the following:", this is per the specs as well.

If `onPickList` is not set, pick list tokens are silently removed and the command is forwarded to the host normally (same as before for applications that don't use this feature).

This part of the spec is used by Legend of The Red Dragon's RIP menus when picking various special skills in the forest fights.